### PR TITLE
Proposed solution to issue #2 with missing collection/project in url

### DIFF
--- a/server/src/jetbrains/buildServer/vsonline/VsOnlineIssueFetcher.java
+++ b/server/src/jetbrains/buildServer/vsonline/VsOnlineIssueFetcher.java
@@ -40,6 +40,7 @@ public class VsOnlineIssueFetcher extends AbstractIssueFetcher {
   // host + / collection / area
   // http://account.visualstudio.com/collection/project
   private final Pattern p = Pattern.compile("^(http[s]?://.+\\.visualstudio.com)/(.+)/(.+)/$");
+  private String fetchHost;
 
   private static final String URL_TEMPLATE_GET_ISSUE = "%s/%s/_apis/wit/workitems/%s?$expand=all&api-version=%s";
 
@@ -86,8 +87,12 @@ public class VsOnlineIssueFetcher extends AbstractIssueFetcher {
     });
   }
 
+  public void setFetchHost(String host) {
+    fetchHost = host;
+  }
+
   @NotNull
   public String getUrl(@NotNull String host, @NotNull String id) {
-    return host + "_workitems/edit/" + id;
+    return fetchHost + "_workitems/edit/" + id;
   }
 }

--- a/server/src/jetbrains/buildServer/vsonline/VsOnlineIssueProvider.java
+++ b/server/src/jetbrains/buildServer/vsonline/VsOnlineIssueProvider.java
@@ -57,6 +57,14 @@ public class VsOnlineIssueProvider extends AbstractIssueProvider {
     }
   }
 
+  @Override
+  public void setProperties(@NotNull Map<String, String> map) {
+    super.setProperties(map);
+    if(myFetcher instanceof VsOnlineIssueFetcher) {
+      ((VsOnlineIssueFetcher) myFetcher).setFetchHost(myFetchHost);
+    }
+  }
+
   @NotNull
   @Override
   protected String getFetchHost() {


### PR DESCRIPTION
I tried figuring out the least invasive way of providing the fetcher with myFetchHost, available in the provider. Since that's what we need in this case, whereas TeamCity supplies myHost in some scenarios which isn't what the plugin expects.

Did some local testing on my machine and it works fine. Will install it on our production machine tomorrow to give it a proper test. Will update when that is done.
